### PR TITLE
Fix Alexa Model working when using this with wyoming-microwakeword

### DIFF
--- a/pymicro_wakeword/const.py
+++ b/pymicro_wakeword/const.py
@@ -9,6 +9,7 @@ class Model(str, Enum):
     OKAY_NABU = "okay_nabu"
     HEY_JARVIS = "hey_jarvis"
     HEY_MYCROFT = "hey_mycroft"
+    ALEXA = "alexa"
 
 
 @dataclass


### PR DESCRIPTION
Hey, great work, I am using this via wyoming-microwakeword.

However, the alexa model isn't working. I suspect this is coming from this project, it said: 

`WARNING:root:Unknown model name: alexa`

However, adding this line to the const.py file from pymicro-wakeword fixed that:

`ALEXA = "alexa"`

This PR adds this change to const.py in hopes to resolve the issue.

PS: With OpenWakeWord the Nabu one was called OK_NABU while here it's OKAY_NABU which might lead to confusion. Maybe you could think about synchronizing the two. 
Also, I noticed this works way better than OpenWakeWord, so there is a point to be made for the wyoming-satellite documentation to be updated and at least reflect the alternative of MicroWakeWord.